### PR TITLE
Add support for torchaudio 0.11

### DIFF
--- a/torch_pitch_shift/main.py
+++ b/torch_pitch_shift/main.py
@@ -149,7 +149,7 @@ def pitch_shift(
     resampler = T.Resample(sample_rate, int(sample_rate / shift)).to(input.device)
     output = input
     output = output.reshape(batch_size * channels, samples)
-    output = torch.stft(output, n_fft, hop_length)[None, ...]
+    output = torch.stft(output, n_fft, hop_length, return_complex=True)[None, ...]
     stretcher = T.TimeStretch(
         fixed_rate=float(1 / shift), n_freq=output.shape[2], hop_length=hop_length
     ).to(input.device)


### PR DESCRIPTION
`torchaudio` 0.11 migrated all functions and transforms to PyTorch native complex Tensor type, which causes `pitch_shift` to break, as described in #1.

This adds support for `torchaudio` v0.11 by changing the default value of `return_complex` to `True` in the `torch.stft` call:

```python
output = torch.stft(output, n_fft, hop_length, return_complex=True)[None, ...]
```