### PR TITLE
Fix Global Warnings Suppression

### DIFF
--- a/example.py
+++ b/example.py
@@ -9,7 +9,7 @@ SAMPLE_RATE, sample = wavfile.read("./wavs/test.wav")
 # convert to tensor of shape (batch_size, channels, samples)
 dtype = sample.dtype
 sample = torch.tensor(
-    [np.swapaxes(sample, 0, 1)],  # (samples, channels) --> (channels, samples)
+    np.expand_dims(np.swapaxes(sample, 0, 1),0),  # (samples, channels) --> (channels, samples)
     dtype=torch.float32,
     device="cuda" if torch.cuda.is_available() else "cpu",
 )

--- a/example.py
+++ b/example.py
@@ -1,6 +1,7 @@
-import torch
 import numpy as np
+import torch
 from scipy.io import wavfile
+
 from torch_pitch_shift import *
 
 # read an audio file
@@ -8,8 +9,11 @@ SAMPLE_RATE, sample = wavfile.read("./wavs/test.wav")
 
 # convert to tensor of shape (batch_size, channels, samples)
 dtype = sample.dtype
+
 sample = torch.tensor(
-    np.expand_dims(np.swapaxes(sample, 0, 1),0),  # (samples, channels) --> (channels, samples)
+    np.expand_dims(
+        np.swapaxes(sample, 0, 1), 0
+    ),  # (samples, channels) --> (channels, samples)
     dtype=torch.float32,
     device="cuda" if torch.cuda.is_available() else "cpu",
 )

--- a/torch_pitch_shift/main.py
+++ b/torch_pitch_shift/main.py
@@ -115,6 +115,7 @@ def pitch_shift(
     bins_per_octave: Optional[int] = 12,
     n_fft: Optional[int] = 0,
     hop_length: Optional[int] = 0,
+    window: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
     Shift the pitch of a batch of waveforms by a given amount.
@@ -134,6 +135,8 @@ def pitch_shift(
         Size of FFT. Default is `sample_rate // 64`.
     hop_length: int [optional]
         Size of hop length. Default is `n_fft // 32`.
+    window: torch.Tensor [optional]
+        A window tensor for the STFT. Default is a tensor of ones.
 
     Returns
     -------
@@ -145,6 +148,9 @@ def pitch_shift(
         n_fft = sample_rate // 64
     if not hop_length:
         hop_length = n_fft // 32
+    if window is None:
+        window = torch.ones(n_fft)
+    window = window.to(input.device)
     batch_size, channels, samples = input.shape
     if not isinstance(shift, Fraction):
         shift = 2.0 ** (float(shift) / bins_per_octave)
@@ -152,12 +158,14 @@ def pitch_shift(
     output = input
     output = output.reshape(batch_size * channels, samples)
     v011 = version.parse(torchaudio.__version__) >= version.parse("0.11.0")
-    output = torch.stft(output, n_fft, hop_length, return_complex=v011)[None, ...]
+    output = torch.stft(output, n_fft, hop_length, return_complex=v011, window=window)[
+        None, ...
+    ]
     stretcher = T.TimeStretch(
         fixed_rate=float(1 / shift), n_freq=output.shape[2], hop_length=hop_length
     ).to(input.device)
     output = stretcher(output)
-    output = torch.istft(output[0], n_fft, hop_length)
+    output = torch.istft(output[0], n_fft, hop_length, window=window)
     output = resampler(output)
     del resampler, stretcher
     if output.shape[1] >= input.shape[2]:

--- a/torch_pitch_shift/main.py
+++ b/torch_pitch_shift/main.py
@@ -1,4 +1,3 @@
-import warnings
 from collections import Counter
 from fractions import Fraction
 from functools import reduce

--- a/torch_pitch_shift/main.py
+++ b/torch_pitch_shift/main.py
@@ -13,7 +13,6 @@ from packaging import version
 from primePy import primes
 from torch.nn.functional import pad
 
-warnings.simplefilter("ignore")
 
 # https://stackoverflow.com/a/46623112/9325832
 def _combinations_without_repetition(r, iterable=None, values=None, counts=None):


### PR DESCRIPTION
Closes #8 by removing the hardcoded `warnings.simplefilter("ignore")` here:
https://github.com/KentoNishi/torch-pitch-shift/blob/04cf7afd6b2d161063f115ba068b1f68f3eedc50/torch_pitch_shift/main.py#L16

I have verified and tested the changes under torch 1.7 (minimum requirement), 1.13, and 2.4 (latest).

Removing the global warning suppression, there are several points of consideration inside the repo:
- Changed the dimension expansion to use numpy in `example.py`. This was a masked warning, as torch seems to not like numpy arrays wrapped in Python lists.
- Both `torch.stft` and `torch.istft` will soon require a window. This is still optional, but gives a warning for torch 2.x. As the user may want to provide an optional `window` attribute to the function, i have added this. If `window` is `None`, `torch.ones` is used, aligning with the default behavior of all torch versions (see their docs), however explicitly setting it gets rid of the warning.

Packages that rely on `torch-pitch-shift`, like [torch-audiomentations](https://github.com/asteroid-team/torch-audiomentations) may be impacted by this change and users could potentially see warnings that were previously masked. However, i would argue that this tradeoff is better than keeping it hardcoded.

Let me know what you think! @KentoNishi 